### PR TITLE
feat(compiler): added initial ast generation

### DIFF
--- a/libs/titanc/src/compiler/ast.rs
+++ b/libs/titanc/src/compiler/ast.rs
@@ -1,0 +1,10 @@
+use crate::compiler::debug::Span;
+
+// This file should contain all our AST nodes
+// the root of our ast is always a scope
+
+#[derive(Debug)]
+pub struct Scope {
+  pub text: String, // this is only here until we add change the grammar
+  pub span: Span
+}

--- a/libs/titanc/src/compiler/debug.rs
+++ b/libs/titanc/src/compiler/debug.rs
@@ -1,3 +1,5 @@
+// Right now the span is very simple, we will probably add more to it later
+// but they hold the start and end column of a node
 #[derive(Debug)]
 pub struct Span {
   pub start: usize,

--- a/libs/titanc/src/compiler/debug.rs
+++ b/libs/titanc/src/compiler/debug.rs
@@ -1,0 +1,5 @@
+#[derive(Debug)]
+pub struct Span {
+  pub start: usize,
+  pub end: usize,
+}

--- a/libs/titanc/src/compiler/parser.rs
+++ b/libs/titanc/src/compiler/parser.rs
@@ -1,0 +1,47 @@
+use tree_sitter::Node;
+use crate::compiler::ast::Scope;
+use crate::compiler::debug::Span;
+use std::str;
+
+pub struct Parser<'a> {
+  pub source_code: &'a [u8],
+}
+
+impl<'b> Parser<'b> {
+  pub fn new(source_code: &'b [u8]) -> Self {
+    Self {
+      source_code
+    }
+  }
+
+  pub fn parse(&self, root: &Node) -> Scope {
+    match root.kind() {
+      "source_file" => self.build_scope(&root),
+      _ => panic!("Unexpected root node kind: {}", root.kind()) // tree-sitter parse tree should always start  with source
+    }
+  }
+
+  pub fn build_scope(&self, root: &Node) -> Scope {
+    let span = self.node_span(&root);
+    let node_text = self.node_text(&root);
+    
+    Scope {
+      text: node_text.to_string(),
+      span
+    }
+  }
+
+  // helper function that takes a node and creates a Span from it
+  pub fn node_span(&self, node: &Node) -> Span {
+    let node_range = node.range();
+    Span {
+      start: node_range.start_byte,
+      end: node_range.end_byte,
+    }
+  }
+
+  // helper that gets the text out of a node
+  fn node_text<'a>(&'a self, node: &Node) -> &'a str {
+		return str::from_utf8(&self.source_code[node.byte_range()]).unwrap();
+	}
+}

--- a/libs/titanc/src/compiler/parser.rs
+++ b/libs/titanc/src/compiler/parser.rs
@@ -3,6 +3,12 @@ use crate::compiler::ast::Scope;
 use crate::compiler::debug::Span;
 use std::str;
 
+// This file will contain our parser, it is responsible for taking the tree-sitter parse tree
+// and converting it into our AST that we will then use in the rest of the compiler
+// when a parser is created it will hold the source code as a byte array so that if we
+// need to extract something from the source code we can do it easily. IE if we need to
+// get the text of a node, we can just get the byte range of the node and then convert
+// that to a string using the source code byte array
 pub struct Parser<'a> {
   pub source_code: &'a [u8],
 }

--- a/libs/titanc/src/main.rs
+++ b/libs/titanc/src/main.rs
@@ -1,5 +1,16 @@
+// until this is converted to a rust library,
+// any files you add in compiler will need to be listed here as mods
+// to be able to use them in other files
+mod compiler {
+  pub mod parser;
+  pub mod ast;
+  pub mod debug;
+}
+
 use std::fs::File;
 use std::io::prelude::*;
+
+use crate::compiler::parser::Parser;
 
 
 // This main entry point will be for debugging
@@ -20,7 +31,7 @@ fn main() {
   file.read_to_string(&mut source_code).unwrap();
 
 
-  let parse_tree = match parser.parse(source_code, None) {
+  let parse_tree = match parser.parse(&source_code, None) {
     Some(tree) => tree,
     None => {
       println!("Error parsing source code");
@@ -28,6 +39,11 @@ fn main() {
     }
   };
 
-  // Dump out parse tree
-  dbg!(parse_tree.root_node().to_sexp());
+  let parser = Parser::new(&source_code.as_bytes());
+
+  // This will be the root of our ast. (which is a scope)
+  let root = parser.parse(&parse_tree.root_node());
+
+  // dump the ast to terminal
+  dbg!(root);
 }


### PR DESCRIPTION
Okay this change to the compiler no longer spits out the parse tree when you run `cargo run` now we have the beginnings of our rust parser. This guy is responsible for reading the tree-sitter parse tree and then converting it to our AST for further compilation/interpretation. 

currently the AST only has a scope node but more will come as we add new grammar

Sample output
<img width="633" alt="image" src="https://github.com/titan-architecture/titan/assets/45375125/27804dbb-81e6-40ff-9a3c-72d48d675fb4">
